### PR TITLE
docs: rewrite README to reflect current aggregation architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,128 @@
-# Weather Proxy - Cloudflare Workers
+# weather-proxy
 
-Weather API 프록시 서버 - API 키를 안전하게 보호하면서 여러 날씨 API를 통합 제공
+Cloudflare Workers 기반 날씨 데이터 집계 프록시 서버.  
+OpenWeather, WeatherAPI, Open-Meteo 세 provider의 데이터를 가중치 평균으로 집계해 반환한다.
 
-## 🎯 목적
+**프로덕션:** `https://weather-proxy.neisii.workers.dev`  
+**서비스 대상:** 대한민국 8개 도시 (서울·부산·인천·대구·광주·대전·울산·제주)
 
-- **보안**: API 키를 클라이언트에 노출하지 않음
-- **인증**: 프록시 자체도 API 키로 보호
-- **통합**: 3개의 날씨 API를 단일 인터페이스로 제공
-- **성능**: Cloudflare 글로벌 엣지 네트워크 활용
-- **무료**: 일일 100,000 requests 무료 제공
+---
 
-## 📡 지원 API
+## 아키텍처
 
-1. **OpenWeatherMap** - Current + Forecast
-2. **WeatherAPI.com** - Current + Forecast  
-3. **Open-Meteo** - Current + Forecast (API 키 불필요)
+```
+클라이언트
+  └─ /api/weather/current     ─┐
+  └─ /api/weather/forecast     ├─ aggregateWeather()  ←  OW + WA + OM 병렬 fetch
+  └─ /api/weather/cities       │                          가중치 평균 집계
+  └─ /api/healthz             ─┘                          in-memory 캐시
+```
 
-## 🚀 빠른 시작
+provider별 기본 가중치:
+
+| 필드 | OpenWeather | WeatherAPI | Open-Meteo |
+|---|---|---|---|
+| 기온 | 0.40 | 0.15 | 0.45 |
+| 풍속 | 0.25 | 0.15 | 0.60 |
+| 습도 | 0.30 | 0.70 | 0.00 |
+
+provider가 실패하거나 이상값을 반환하면 weight를 나머지에 재분배해 집계를 계속한다.
+
+---
+
+## 엔드포인트
+
+### 공개 (인증 불필요)
+
+#### `GET /api/healthz`
+```json
+{ "status": "ok" }
+```
+
+#### `GET /api/weather/cities`
+```json
+{
+  "cities": [
+    { "id": "seoul", "name": "서울", "lat": 37.5683, "lon": 126.9778 },
+    ...
+  ]
+}
+```
+
+#### `GET /api/weather/current?cityId={id}`
+
+```json
+{
+  "weather": {
+    "temp": 21.9,
+    "feels_like": 21.2,
+    "temp_max": 24.1,
+    "temp_min": 19.3,
+    "humidity": 45,
+    "pressure": 1013,
+    "wind_speed": 3.2,
+    "wind_deg": 180,
+    "condition": "partly_cloudy",
+    "precip_mm": 0,
+    "precip_prob": 0,
+    "uv_index": 4.2,
+    "visibility": 10000
+  },
+  "confidence": { "temp": 0.95, "wind": 0.88, "humidity": 0.92, "overall": 0.92 },
+  "providers_used": ["openweather", "weatherapi", "openmeteo"],
+  "providers_failed": [],
+  "incomplete_data": false,
+  "cached_at": "2026-04-30T06:03:33.580Z"
+}
+```
+
+캐시 TTL: **5분**
+
+#### `GET /api/weather/forecast?cityId={id}&days={1|2|3}`
+
+```json
+{
+  "days": [
+    { "date": "2026-04-30", "weather": { ... } },
+    { "date": "2026-05-01", "weather": { ... } },
+    { "date": "2026-05-02", "weather": { ... } }
+  ],
+  "providers_used": ["openweather", "weatherapi", "openmeteo"],
+  "providers_failed": [],
+  "incomplete_data": false,
+  "cached_at": "2026-04-30T06:03:33.580Z"
+}
+```
+
+- `days` 기본값: `3` (최대 3)
+- 날짜는 KST 기준 `YYYY-MM-DD`
+- 캐시 TTL: **30분** (provider 모델 갱신 주기 ~6시간 대비 최적화)
+
+---
+
+### 인증 필요 (`X-API-Key` 헤더)
+
+개발자 디버깅 및 provider 원본 응답 확인용. 클라이언트 앱에서는 사용하지 않는다.
+
+| 엔드포인트 | 용도 |
+|---|---|
+| `GET /api/weather/forecast/debug?cityId={id}&days={n}` | per-provider 집계 원본 데이터 |
+| `GET /api/openweather/current?cityId={id}` | OpenWeather raw passthrough |
+| `GET /api/openweather/forecast?cityId={id}` | OpenWeather raw passthrough |
+| `GET /api/weatherapi/current?cityId={id}` | WeatherAPI raw passthrough |
+| `GET /api/weatherapi/forecast?cityId={id}` | WeatherAPI raw passthrough |
+| `GET /api/openmeteo?cityId={id}` | Open-Meteo raw passthrough |
+
+```bash
+curl -H "X-API-Key: $PROXY_API_KEY" \
+  "https://weather-proxy.neisii.workers.dev/api/weather/forecast/debug?cityId=seoul&days=3"
+```
+
+인증 실패 시 `401 Unauthorized`.
+
+---
+
+## 로컬 개발
 
 ### 1. 의존성 설치
 
@@ -24,338 +130,92 @@ Weather API 프록시 서버 - API 키를 안전하게 보호하면서 여러 �
 npm install
 ```
 
-### 2. 환경 설정
+### 2. 환경 변수 설정
 
-로컬 개발용 `.dev.vars` 파일 생성:
+`.dev.vars` 파일 생성 (git 제외됨):
 
 ```bash
-# .dev.vars
-OPENWEATHER_API_KEY=your_openweather_key_here
-WEATHERAPI_API_KEY=your_weatherapi_key_here
-PROXY_API_KEY=your_proxy_secret_key_here
+OPENWEATHER_API_KEY=your_openweather_key
+WEATHERAPI_API_KEY=your_weatherapi_key
+PROXY_API_KEY=your_proxy_secret
 ```
 
-⚠️ **주의**: `.dev.vars` 파일은 git에 커밋하지 마세요! (이미 .gitignore에 포함됨)
-
-### 3. 로컬 개발 서버 실행
+### 3. 개발 서버 실행
 
 ```bash
 npm run dev
+# http://localhost:8787
 ```
 
-서버가 `http://localhost:8787`에서 실행됩니다.
+---
 
-### 4. 테스트
-
-모든 요청에 `X-API-Key` 헤더가 필요합니다:
+## 테스트
 
 ```bash
-# OpenWeatherMap
-curl -H "X-API-Key: your_proxy_secret_key_here" \
-  "http://localhost:8787/api/openweather/current?city=Seoul"
+# 단위 테스트 (normalizer, aggregation — 61개)
+npm test
 
-# WeatherAPI
-curl -H "X-API-Key: your_proxy_secret_key_here" \
-  "http://localhost:8787/api/weatherapi/current?city=Seoul"
-
-# Open-Meteo
-curl -H "X-API-Key: your_proxy_secret_key_here" \
-  "http://localhost:8787/api/openmeteo?lat=37.5683&lon=126.9778"
+# 프로덕션 E2E 테스트 (27개, 실제 프로덕션 타격)
+npm run test:e2e
 ```
 
-## 📚 API 문서
+E2E 테스트 커버리지: 8개 도시 전체, days=1/2/3, KST 날짜 정합성, 필드 범위 검증, 인증, CORS, 엣지케이스.
 
-### 공통 요청 헤더
+---
 
-| 헤더 | 필수 | 설명 |
-|------|------|------|
-| `X-API-Key` | ✅ | 프록시 인증 키 (`PROXY_API_KEY` 값) |
+## 배포
 
-인증 실패 시 `401 Unauthorized` 반환:
-```json
-{ "error": { "code": "UNAUTHORIZED", "message": "Invalid or missing API key" } }
-```
-
-### OpenWeatherMap
-
-#### Current Weather
-```
-GET /api/openweather/current?city={city}
-```
-
-**Parameters:**
-- `city` (required): 도시 이름 (예: Seoul, Busan)
-
-**Response:**
-```json
-{
-  "coord": { "lon": 126.9778, "lat": 37.5683 },
-  "weather": [...],
-  "main": {
-    "temp": 15.2,
-    "feels_like": 14.5,
-    "humidity": 65
-  },
-  "wind": { "speed": 3.5 },
-  "name": "Seoul"
-}
-```
-
-#### Forecast
-```
-GET /api/openweather/forecast?city={city}
-```
-
-### WeatherAPI
-
-#### Current Weather
-```
-GET /api/weatherapi/current?city={city}
-```
-
-**Response:**
-```json
-{
-  "location": {
-    "name": "Seoul",
-    "lat": 37.57,
-    "lon": 126.98
-  },
-  "current": {
-    "temp_c": 15.2,
-    "condition": { "text": "Partly cloudy" },
-    "wind_kph": 12.6,
-    "humidity": 65
-  }
-}
-```
-
-#### Forecast
-```
-GET /api/weatherapi/forecast?city={city}
-```
-
-### Open-Meteo
-
-```
-GET /api/openmeteo?lat={lat}&lon={lon}
-```
-
-**Parameters:**
-- `lat` (required): 위도 (-90 ~ 90)
-- `lon` (required): 경도 (-180 ~ 180)
-
-**Response:**
-```json
-{
-  "current_weather": {
-    "temperature": 15.2,
-    "windspeed": 12.5,
-    "weathercode": 0
-  },
-  "hourly": {
-    "time": [...],
-    "temperature_2m": [...]
-  }
-}
-```
-
-## 🔒 보안
-
-### 인증 (Authentication)
-
-모든 엔드포인트는 `X-API-Key` 헤더를 요구합니다.
-
-- **로컬**: `.dev.vars`의 `PROXY_API_KEY` 값 사용
-- **프로덕션**: Cloudflare Secret으로 설정 (`wrangler secret put PROXY_API_KEY`)
-- 헤더 미포함 또는 값 불일치 시 → `401 Unauthorized`
-
-프론트엔드에서 사용 예:
-```javascript
-fetch('https://weather-proxy.{subdomain}.workers.dev/api/openweather/current?city=Seoul', {
-  headers: { 'X-API-Key': import.meta.env.VITE_PROXY_API_KEY }
-})
-```
-
-### API 키 관리
-
-**로컬 개발:**
-- `.dev.vars` 파일에 저장
-- Git에 커밋하지 않음
-
-**프로덕션 배포:**
 ```bash
-# Cloudflare Secrets로 안전하게 저장
+# Secrets 설정 (최초 1회)
 wrangler secret put OPENWEATHER_API_KEY
 wrangler secret put WEATHERAPI_API_KEY
 wrangler secret put PROXY_API_KEY
-```
 
-### CORS
-
-`wrangler.toml`의 `ALLOWED_ORIGINS` 변수로 제어합니다:
-
-```toml
-[vars]
-ALLOWED_ORIGINS = "*"  # 개발용 (모든 origin 허용)
-# ALLOWED_ORIGINS = "https://yourdomain.com"  # 프로덕션용
-```
-
-프로덕션에서는 실제 프론트엔드 도메인으로 변경하세요.
-
-## 🚢 배포
-
-### 1. Cloudflare 계정 로그인
-
-```bash
-wrangler login
-```
-
-### 2. Secrets 설정
-
-```bash
-wrangler secret put OPENWEATHER_API_KEY
-# 프롬프트에 실제 API 키 입력
-
-wrangler secret put WEATHERAPI_API_KEY
-# 프롬프트에 실제 API 키 입력
-
-wrangler secret put PROXY_API_KEY
-# 프롬프트에 프록시 인증용 시크릿 키 입력
-```
-
-### 3. ALLOWED_ORIGINS 설정 (선택)
-
-`wrangler.toml`에서 프론트엔드 도메인으로 변경:
-```toml
-ALLOWED_ORIGINS = "https://yourdomain.com"
-```
-
-### 4. 배포
-
-```bash
+# 배포
 npm run deploy
 ```
 
-배포 후 Worker URL 확인:
+---
+
+## 프로젝트 구조
+
 ```
-https://weather-proxy.{your-subdomain}.workers.dev
+src/
+├── index.ts                  라우터 — 경로 디스패치, 2-tier 인증 게이트
+├── handlers/
+│   ├── weather.ts            집계 핵심 로직 (normalizer, aggregation, cache, handler)
+│   ├── openweather.ts        OW raw passthrough
+│   ├── weatherapi.ts         WA raw passthrough
+│   ├── openmeteo.ts          OM raw passthrough
+│   └── health.ts             /api/healthz
+├── types/env.ts              Worker env 타입
+├── utils/
+│   ├── cors.ts               CORS 헤더
+│   └── errors.ts             에러 응답 형식
+└── __tests__/
+    ├── aggregation.test.ts   단위 테스트
+    ├── normalizers.test.ts   단위 테스트
+    ├── forecast-debug.test.ts 단위 테스트
+    └── e2e/
+        └── production.test.ts E2E 테스트
+docs/
+├── decisions/                ADR (001~004)
+└── *.md                      설계 문서, 엣지케이스 분석
 ```
 
-## 📊 모니터링
+---
 
-### 실시간 로그
+## 모니터링
 
 ```bash
+# 실시간 로그
 npm run tail
 ```
 
-### Cloudflare Dashboard
+Cloudflare Dashboard → Workers & Pages → weather-proxy → Analytics
 
-1. [Cloudflare Dashboard](https://dash.cloudflare.com) 접속
-2. Workers & Pages → weather-proxy 선택
-3. Analytics 탭에서 메트릭 확인:
-   - Requests
-   - Success rate
-   - Error rate
-   - Duration
+---
 
-## 🔧 개발
-
-### 프로젝트 구조
-
-```
-weather-proxy/
-├── src/
-│   ├── index.ts              # 메인 Worker (라우팅, 인증)
-│   ├── handlers/
-│   │   ├── openweather.ts    # OpenWeatherMap 핸들러
-│   │   ├── weatherapi.ts     # WeatherAPI 핸들러
-│   │   └── openmeteo.ts      # Open-Meteo 핸들러
-│   ├── utils/
-│   │   ├── cors.ts           # CORS 헤더 (origin allowlist)
-│   │   ├── errors.ts         # 에러 핸들링
-│   │   └── response.ts       # 응답 포맷
-│   └── types/
-│       └── env.ts            # 환경 변수 타입
-├── wrangler.toml             # Cloudflare 설정
-├── package.json
-└── tsconfig.json
-```
-
-### 새 엔드포인트 추가
-
-1. `src/handlers/`에 새 핸들러 생성
-2. `src/index.ts`에 라우팅 추가
-3. 로컬 테스트
-4. 배포
-
-## 📈 사용량 제한
-
-### Cloudflare Workers Free Tier
-
-- **일일 100,000 requests** (매일 00:00 UTC 리셋)
-- 개인 사용: 하루 100번 검색 = 300 requests
-- **여유도: 333배**
-
-### 예상 사용량
-
-**개인 사용:**
-- 검색 10회/일 × 3 providers = 30 requests/일
-- 월간: 900 requests
-
-**소규모 공개 (100명):**
-- 검색 5회/인 × 100명 × 3 providers = 1,500 requests/일
-- 월간: 45,000 requests
-
-**결론**: 무료 제한으로 충분히 운영 가능
-
-## 🐛 문제 해결
-
-### 401 Unauthorized
-
-**원인**: `X-API-Key` 헤더가 없거나 값이 틀림
-
-**해결:**
-```bash
-# 요청 시 헤더 포함 확인
-curl -H "X-API-Key: your_proxy_secret_key_here" "http://localhost:8787/..."
-
-# 로컬: .dev.vars에 PROXY_API_KEY 설정 확인
-# 프로덕션: wrangler secret put PROXY_API_KEY
-```
-
-### "Missing required field: OPENWEATHER_API_KEY"
-
-**원인**: API 키가 설정되지 않음
-
-**해결:**
-```bash
-# 로컬: .dev.vars 파일에 키 추가
-# 프로덕션: Secrets 설정
-wrangler secret put OPENWEATHER_API_KEY
-```
-
-### CORS 에러
-
-**원인**: 요청 origin이 `ALLOWED_ORIGINS`에 없음
-
-**해결:** `wrangler.toml`의 `ALLOWED_ORIGINS`에 프론트엔드 도메인 추가
-
-### 502 Bad Gateway
-
-**원인**: 외부 API 호출 실패
-
-**해결:**
-- API 키 확인
-- 외부 API 상태 확인
-- 로그 확인 (`wrangler tail`)
-
-## 📝 라이선스
+## 라이선스
 
 MIT
-
-## 🔗 관련 문서
-
-- [Cloudflare Workers 문서](https://developers.cloudflare.com/workers/)
-- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/)


### PR DESCRIPTION
## Summary

초기 단순 passthrough 구조 기준으로 작성된 README를 현재 아키텍처에 맞게 전면 재작성.

## 주요 변경

- 2-tier 인증 구조 (공개 vs X-API-Key 필요) 반영
- 집계/가중치 평균 아키텍처 다이어그램 추가
- 8개 도시 제한 및 KST 날짜 기준 명시
- 캐시 TTL (current 5분 / forecast 30분) 명시
- 테스트 섹션 추가 (`npm test` / `npm run test:e2e`)
- 프로젝트 구조 현행화
- 프로덕션 URL 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)